### PR TITLE
feat: sync entries with edge config

### DIFF
--- a/api/update-config.js
+++ b/api/update-config.js
@@ -1,0 +1,46 @@
+/**
+ * Updates Vercel Edge Config with the provided data.
+ *
+ * Expected request body:
+ * {
+ *   incomeEntries: Array<IncomeEntry>,
+ *   expenseEntries: Array<ExpenseEntry>
+ * }
+ */
+
+export default async function handler(req, res) {
+  if (req.method !== 'PATCH') {
+    res.setHeader('Allow', ['PATCH']);
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { VERCEL_EDGE_CONFIG_ID, VERCEL_EDGE_CONFIG_TOKEN } = process.env;
+  if (!VERCEL_EDGE_CONFIG_ID || !VERCEL_EDGE_CONFIG_TOKEN) {
+    return res.status(500).json({ error: 'Missing Edge Config credentials' });
+  }
+
+  try {
+    let body = req.body;
+    if (typeof body === 'string') {
+      body = JSON.parse(body);
+    }
+
+    const response = await fetch(`https://api.vercel.com/v1/edge-config/${VERCEL_EDGE_CONFIG_ID}/items`, {
+      method: 'PATCH',
+      headers: {
+        'Authorization': `Bearer ${VERCEL_EDGE_CONFIG_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        items: [
+          { operation: 'upsert', key: 'data', value: body },
+        ],
+      }),
+    });
+
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}

--- a/src/db.js
+++ b/src/db.js
@@ -1,17 +1,42 @@
 import Dexie from 'dexie';
 
+/**
+ * Data stored in Edge Config under the `data` key follows this shape:
+ * {
+ *   incomeEntries: Array<IncomeEntry>,
+ *   expenseEntries: Array<ExpenseEntry>
+ * }
+ */
+
 const db = new Dexie('FinanceAppDatabase');
 db.version(1).stores({
   incomeEntries: '++id,category,amount',
   expenseEntries: '++id,category,amount',
 });
 
-export const addIncomeEntry = (entry) => {
-  return db.incomeEntries.add(entry);
+const syncEdgeConfig = async () => {
+  const [incomeEntries, expenseEntries] = await Promise.all([
+    db.incomeEntries.toArray(),
+    db.expenseEntries.toArray(),
+  ]);
+
+  await fetch('/api/update-config', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ incomeEntries, expenseEntries }),
+  });
 };
 
-export const addExpenseEntry = (entry) => {
-  return db.expenseEntries.add(entry);
+export const addIncomeEntry = async (entry) => {
+  const id = await db.incomeEntries.add(entry);
+  await syncEdgeConfig();
+  return id;
+};
+
+export const addExpenseEntry = async (entry) => {
+  const id = await db.expenseEntries.add(entry);
+  await syncEdgeConfig();
+  return id;
 };
 
 export const getIncomeEntries = () => {
@@ -22,13 +47,15 @@ export const getExpenseEntries = () => {
   return db.expenseEntries.toArray();
 };
 
-export const deleteIncomeEntry = (id) => {
-    return db.incomeEntries.where('id').equals(Number(id)).delete();
-  };
-  
-  export const deleteExpenseEntry = (id) => {
-    return db.expenseEntries.where('id').equals(Number(id)).delete();
-  };
+export const deleteIncomeEntry = async (id) => {
+  await db.incomeEntries.where('id').equals(Number(id)).delete();
+  await syncEdgeConfig();
+};
+
+export const deleteExpenseEntry = async (id) => {
+  await db.expenseEntries.where('id').equals(Number(id)).delete();
+  await syncEdgeConfig();
+};
 
 export const openDB = async () => {
   await db.open();


### PR DESCRIPTION
## Summary
- add API route to update Vercel Edge Config with income and expense entries
- call new endpoint from IndexedDB helpers to keep Edge Config in sync

## Testing
- `npm test -- --watchAll=false` *(fails: window.matchMedia is not a function / IndexedDB API missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f1cf02c5883258fd0a13a87867cd6