### PR TITLE
Refactor entry handlers and simplify database utility

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,58 +29,32 @@ function App() {
   };
 
   const handleEntrySubmit = async (entry, type) => {
-    if (type === 'income') {
-
-      await addIncomeEntry(entry);
-      await updateIncomeEntries();
-    } else {
-      await addExpenseEntry(entry);
-      await updateExpenseEntries();
-
-      addIncomeEntry(entry)
-        .then(() => {
-          updateIncomeEntries();
-        })
-        .catch((err) => {
-          message.error(`Не удалось добавить доход: ${err.message}`);
-        });
-    } else {
-      addExpenseEntry(entry)
-        .then(() => {
-          updateExpenseEntries();
-        })
-        .catch((err) => {
-          message.error(`Не удалось добавить расход: ${err.message}`);
-        });
-
+    try {
+      if (type === 'income') {
+        await addIncomeEntry(entry);
+        await updateIncomeEntries();
+      } else {
+        await addExpenseEntry(entry);
+        await updateExpenseEntries();
+      }
+    } catch (err) {
+      const action = type === 'income' ? 'добавить доход' : 'добавить расход';
+      message.error(`Не удалось ${action}: ${err.message}`);
     }
   };
 
   const handleEntryDelete = async (entry, type) => {
-    if (type === 'income') {
-
-      await deleteIncomeEntry(entry.id);
-      await updateIncomeEntries();
-    } else {
-      await deleteExpenseEntry(entry.id);
-      await updateExpenseEntries();
-
-      deleteIncomeEntry(entry.id)
-        .then(() => {
-          updateIncomeEntries();
-        })
-        .catch((err) => {
-          message.error(`Не удалось удалить доход: ${err.message}`);
-        });
-    } else {
-      deleteExpenseEntry(entry.id)
-        .then(() => {
-          updateExpenseEntries();
-        })
-        .catch((err) => {
-          message.error(`Не удалось удалить расход: ${err.message}`);
-        });
-
+    try {
+      if (type === 'income') {
+        await deleteIncomeEntry(entry.id);
+        await updateIncomeEntries();
+      } else {
+        await deleteExpenseEntry(entry.id);
+        await updateExpenseEntries();
+      }
+    } catch (err) {
+      const action = type === 'income' ? 'удалить доход' : 'удалить расход';
+      message.error(`Не удалось ${action}: ${err.message}`);
     }
   };
 

--- a/src/db.js
+++ b/src/db.js
@@ -1,10 +1,7 @@
-
 export const addIncomeEntry = async (entry) => {
   const res = await fetch('/api/income', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(entry),
   });
   return res.json();
@@ -13,9 +10,7 @@ export const addIncomeEntry = async (entry) => {
 export const addExpenseEntry = async (entry) => {
   const res = await fetch('/api/expense', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(entry),
   });
   return res.json();
@@ -32,122 +27,9 @@ export const getExpenseEntries = async () => {
 };
 
 export const deleteIncomeEntry = async (id) => {
-  await fetch(`/api/income?id=${id}`, {
-    method: 'DELETE',
-  });
+  await fetch(`/api/income?id=${id}`, { method: 'DELETE' });
 };
 
 export const deleteExpenseEntry = async (id) => {
-  await fetch(`/api/expense?id=${id}`, {
-    method: 'DELETE',
-  });
+  await fetch(`/api/expense?id=${id}`, { method: 'DELETE' });
 };
-
-const API_BASE_URL = '/api';
-
-/**
- * Wrapper around fetch providing consistent error handling.
- * @param {string} endpoint API endpoint relative to base URL.
- * @param {RequestInit} options Fetch options.
- * @returns {Promise<any>} Parsed JSON response.
- * @throws {Error} Detailed error describing network or server issues.
- */
-const request = async (endpoint, options = {}) => {
-  try {
-    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
-      headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
-      ...options,
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(text || `Request failed with status ${response.status}`);
-    }
-
-    // Attempt to parse JSON, falling back to empty object for no content.
-    const contentType = response.headers.get('content-type') || '';
-    if (contentType.includes('application/json')) {
-      return await response.json();
-    }
-
-    return {};
-  } catch (error) {
-    throw new Error(`Network error: ${error.message}`);
-  }
-};
-
-export const addIncomeEntry = (entry) =>
-  request('/income', { method: 'POST', body: JSON.stringify(entry) });
-
-export const addExpenseEntry = (entry) =>
-  request('/expense', { method: 'POST', body: JSON.stringify(entry) });
-
-export const getIncomeEntries = () => request('/income');
-
-/**
- * Data stored in Edge Config under the `data` key follows this shape:
- * {
- *   incomeEntries: Array<IncomeEntry>,
- *   expenseEntries: Array<ExpenseEntry>
- * }
- */
-
-const db = new Dexie('FinanceAppDatabase');
-db.version(1).stores({
-  incomeEntries: '++id,category,amount',
-  expenseEntries: '++id,category,amount',
-});
-
-const syncEdgeConfig = async () => {
-  const [incomeEntries, expenseEntries] = await Promise.all([
-    db.incomeEntries.toArray(),
-    db.expenseEntries.toArray(),
-  ]);
-
-  await fetch('/api/update-config', {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ incomeEntries, expenseEntries }),
-  });
-};
-
-export const addIncomeEntry = async (entry) => {
-  const id = await db.incomeEntries.add(entry);
-  await syncEdgeConfig();
-  return id;
-};
-
-export const addExpenseEntry = async (entry) => {
-  const id = await db.expenseEntries.add(entry);
-  await syncEdgeConfig();
-  return id;
-};
-
-
-export const getExpenseEntries = () => request('/expense');
-
-export const deleteIncomeEntry = (id) =>
-  request(`/income/${id}`, { method: 'DELETE' });
-
-export const deleteExpenseEntry = (id) =>
-  request(`/expense/${id}`, { method: 'DELETE' });
-
-export const openDB = async () => Promise.resolve();
-
-export default {};
-
-export const deleteIncomeEntry = async (id) => {
-  await db.incomeEntries.where('id').equals(Number(id)).delete();
-  await syncEdgeConfig();
-};
-
-export const deleteExpenseEntry = async (id) => {
-  await db.expenseEntries.where('id').equals(Number(id)).delete();
-  await syncEdgeConfig();
-};
-
-export const openDB = async () => {
-  await db.open();
-  return db;
-};
-


### PR DESCRIPTION
## Summary
- refactor entry submission and deletion handlers to use single if/else inside try/catch for clearer error messaging
- trim duplicated logic in db utility to a concise set of CRUD helpers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f2197303083259640f1c9fe1eb868