### PR TITLE
Remove duplicate delete handlers

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -27,7 +27,6 @@ export const getExpenseEntries = async () => {
 };
 
 export const deleteIncomeEntry = async (id) => {
-
   await fetch(`/api/income?id=${id}`, {
     method: 'DELETE',
   });
@@ -37,13 +36,5 @@ export const deleteExpenseEntry = async (id) => {
   await fetch(`/api/expense?id=${id}`, {
     method: 'DELETE',
   });
-};
-
-
-  await fetch(`/api/income?id=${id}`, { method: 'DELETE' });
-};
-
-export const deleteExpenseEntry = async (id) => {
-  await fetch(`/api/expense?id=${id}`, { method: 'DELETE' });
 };
 


### PR DESCRIPTION
## Summary
- remove stray duplicate deletion code from db.js, leaving only one deleteIncomeEntry and one deleteExpenseEntry export

## Testing
- `CI=true npm test` *(fails: SyntaxError in setupTests.js)*

------
https://chatgpt.com/codex/tasks/task_e_689f24d4956c8325ba7f5f4c2c075c79