### PR TITLE
Add entry IDs and ensure API stores them

### DIFF
--- a/api/expense.js
+++ b/api/expense.js
@@ -18,7 +18,10 @@ module.exports = async function handler(req, res) {
     }
   } else if (method === 'POST') {
     try {
-      const entry = req.body;
+      const entry = { ...req.body };
+      if (!entry.id) {
+        entry.id = Date.now();
+      }
       const data = (await client.get(KEY)) || [];
       data.push(entry);
       await client.set(KEY, data);

--- a/api/income.js
+++ b/api/income.js
@@ -18,7 +18,10 @@ module.exports = async function handler(req, res) {
     }
   } else if (method === 'POST') {
     try {
-      const entry = req.body;
+      const entry = { ...req.body };
+      if (!entry.id) {
+        entry.id = Date.now();
+      }
       const data = (await client.get(KEY)) || [];
       data.push(entry);
       await client.set(KEY, data);

--- a/src/EntryForm.js
+++ b/src/EntryForm.js
@@ -16,6 +16,7 @@ const EntryForm = ({ categories, onSubmit }) => {
     const entry = {
       ...values,
       type, // Передаем тип из состояния
+      id: Date.now(), // Уникальный идентификатор для последующего удаления
     };
     onSubmit(entry, type); // Теперь передаем тип снова в onSubmit
     form.resetFields();


### PR DESCRIPTION
## Summary
- Generate unique `id` when creating an entry in `EntryForm`
- Ensure API handlers assign an `id` if missing for income and expense entries

## Testing
- `npm test --silent -- --watchAll=false` (fails: SyntaxError in setupTests.js)


------
https://chatgpt.com/codex/tasks/task_e_689f24d5588c8325b139a119a2fd6a14