### PR TITLE
Remove redundant error messages in entry handlers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,14 +38,8 @@ function App() {
         await updateExpenseEntries();
       }
     } catch (err) {
-
-      message.error(
-        `Не удалось добавить ${type === 'income' ? 'доход' : 'расход'}: ${err.message}`
-      );
-
       const action = type === 'income' ? 'добавить доход' : 'добавить расход';
       message.error(`Не удалось ${action}: ${err.message}`);
-
     }
   };
 
@@ -59,14 +53,8 @@ function App() {
         await updateExpenseEntries();
       }
     } catch (err) {
-
-      message.error(
-        `Не удалось удалить ${type === 'income' ? 'доход' : 'расход'}: ${err.message}`
-      );
-
       const action = type === 'income' ? 'удалить доход' : 'удалить расход';
       message.error(`Не удалось ${action}: ${err.message}`);
-
     }
   };
 


### PR DESCRIPTION
## Summary
- streamline error handling in `handleEntrySubmit` and `handleEntryDelete` by emitting a single descriptive message per catch

## Testing
- `npm test -- --watchAll=false` *(fails: SyntaxError in setupTests.js)*

------
https://chatgpt.com/codex/tasks/task_e_689f24d79da08325a52de7fa1963dd7f