### PR TITLE
Use CommonJS export for update-config handler

### DIFF
--- a/api/update-config.js
+++ b/api/update-config.js
@@ -8,7 +8,7 @@
  * }
  */
 
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
   if (req.method !== 'PATCH') {
     res.setHeader('Allow', ['PATCH']);
     return res.status(405).json({ error: 'Method not allowed' });


### PR DESCRIPTION
## Summary
- replace ES module default export with CommonJS export for api/update-config handler

## Testing
- `npm test -- --watchAll=false` *(fails: SyntaxError in src/setupTests.js)*

------
https://chatgpt.com/codex/tasks/task_e_689f24e2a6c88325952c9ba62dbae126