### PR TITLE
Add unique keys to entry list items and generate IDs

### DIFF
--- a/src/EntryForm.js
+++ b/src/EntryForm.js
@@ -14,6 +14,7 @@ const EntryForm = ({ categories, onSubmit }) => {
 
   const onFinish = (values) => {
     const entry = {
+      id: crypto.randomUUID(),
       ...values,
       type, // Передаем тип из состояния
     };

--- a/src/EntryList.js
+++ b/src/EntryList.js
@@ -17,7 +17,7 @@ const EntryList = ({ entries, type, onDelete }) => {
       itemLayout="horizontal"
       dataSource={entries}
       renderItem={(entry) => (
-        <List.Item>
+        <List.Item key={entry.id}>
           <List.Item.Meta
             avatar={IconComponent}
             title={entry.category}


### PR DESCRIPTION
## Summary
- Assign unique keys to list items using entry IDs
- Generate unique IDs for new entries upon submission

## Testing
- `npm test --silent -- --watchAll=false` *(fails: SyntaxError in setupTests.js)*

------
https://chatgpt.com/codex/tasks/task_e_689f24dee26c83259e492c41063b5e89