### PR TITLE
Clean up App tests and mocks

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,77 +1,73 @@
-import { render, screen } from '@testing-library/react';
-
-jest.mock('./db', () => ({
-  __esModule: true,
-  openDB: () => Promise.resolve(),
-  addIncomeEntry: () => Promise.resolve(),
-  addExpenseEntry: () => Promise.resolve(),
-  getIncomeEntries: () => Promise.resolve([]),
-  getExpenseEntries: () => Promise.resolve([]),
-  deleteIncomeEntry: () => Promise.resolve(),
-  deleteExpenseEntry: () => Promise.resolve(),
-}));
-
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { message } from 'antd';
 import App from './App';
 import * as db from './db';
 
-test('renders input form title', () => {
-  render(<App />);
-  const title = screen.getByText(/Ввод данных/i);
-  expect(title).toBeInTheDocument();
+jest.mock('./db', () => ({
+  openDB: jest.fn(),
+  addIncomeEntry: jest.fn(),
+  addExpenseEntry: jest.fn(),
+  getIncomeEntries: jest.fn(),
+  getExpenseEntries: jest.fn(),
+  deleteIncomeEntry: jest.fn(),
+  deleteExpenseEntry: jest.fn(),
+}));
 
-test('renders entry form title', () => {
-  render(<App />);
-  const titleElement = screen.getByText(/Ввод данных/i);
-  expect(titleElement).toBeInTheDocument();
-
-jest.mock('./EntryForm', () => ({ onSubmit }) => (
-  <button onClick={() => onSubmit({ category: 'Test', amount: 100 }, 'income')}>
-    submit
-  </button>
+jest.mock('./EntryForm', () => ({ categories, onSubmit }) => (
+  <button onClick={() => onSubmit({ category: 'Test', amount: 100 }, 'income')}>submit</button>
 ));
 
-jest.mock('./EntryList', () => ({ entries = [], onDelete }) => (
-  entries.length ? <button onClick={() => onDelete(entries[0])}>delete</button> : null
-));
+jest.mock(
+  './EntryList',
+  () =>
+    ({ entries = [], type, onDelete }) =>
+      entries.length ? (
+        <button onClick={() => onDelete(entries[0])}>delete</button>
+      ) : null
+);
 
-jest.mock('./db');
-
-describe('App server failure handling', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    db.openDB.mockResolvedValue(undefined);
-    db.getIncomeEntries.mockResolvedValue([]);
-    db.getExpenseEntries.mockResolvedValue([]);
-  });
-
-  test('shows error notification when submit fails', async () => {
-    db.addIncomeEntry.mockRejectedValueOnce(new Error('Submit failed'));
-    const spy = jest.spyOn(message, 'error').mockImplementation(() => {});
-
+describe('App', () => {
+  test('renders entry form title', () => {
     render(<App />);
-    fireEvent.click(screen.getByText('submit'));
-
-    await waitFor(() =>
-      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Submit failed'))
-    );
+    expect(screen.getByText(/Ввод данных/i)).toBeInTheDocument();
   });
 
-  test('shows error notification when delete fails', async () => {
-    db.getIncomeEntries.mockResolvedValueOnce([{ id: 1, category: 'Test', amount: 100 }]);
-    db.deleteIncomeEntry.mockRejectedValueOnce(new Error('Delete failed'));
-    const spy = jest.spyOn(message, 'error').mockImplementation(() => {});
+  describe('server failure handling', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      db.openDB.mockResolvedValue(undefined);
+      db.getIncomeEntries.mockResolvedValue([]);
+      db.getExpenseEntries.mockResolvedValue([]);
+    });
 
-    render(<App />);
+    test('shows error notification when submit fails', async () => {
+      db.addIncomeEntry.mockRejectedValueOnce(new Error('Submit failed'));
+      const spy = jest.spyOn(message, 'error').mockImplementation(() => {});
 
-    await waitFor(() => screen.getByText('delete'));
-    fireEvent.click(screen.getByText('delete'));
+      render(<App />);
+      fireEvent.click(screen.getByText('submit'));
 
-    await waitFor(() =>
-      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Delete failed'))
-    );
+      await waitFor(() =>
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('Submit failed'))
+      );
+    });
+
+    test('shows error notification when delete fails', async () => {
+      db.getIncomeEntries.mockResolvedValueOnce([
+        { id: 1, category: 'Test', amount: 100 },
+      ]);
+      db.deleteIncomeEntry.mockRejectedValueOnce(new Error('Delete failed'));
+      const spy = jest.spyOn(message, 'error').mockImplementation(() => {});
+
+      render(<App />);
+
+      await waitFor(() => screen.getByText('delete'));
+      fireEvent.click(screen.getByText('delete'));
+
+      await waitFor(() =>
+        expect(spy).toHaveBeenCalledWith(expect.stringContaining('Delete failed'))
+      );
+    });
   });
-
 });
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,46 +1,17 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 
-window.matchMedia = window.matchMedia || function (query) {
-  return {
-    matches: false,
-    media: query,
-    onchange: null,
-
-// Polyfill window.matchMedia for Ant Design
+// Polyfill window.matchMedia for Ant Design components
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: (query) => ({
     matches: false,
     media: query,
     onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
-
-// Ant Design relies on matchMedia. Provide a basic mock for the test environment.
-if (typeof window !== 'undefined' && !window.matchMedia) {
-  window.matchMedia = () => ({
-    matches: false,
-    media: '',
-    onchange: null,
-
     addListener: jest.fn(),
     removeListener: jest.fn(),
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
-
-  };
-};
-
-  });
-}
+  }),
+});
 


### PR DESCRIPTION
## Summary
- streamline App tests by removing duplicate imports and invalid code
- organize tests into describe/test blocks and update mocks to match component API
- simplify test setup with a focused `matchMedia` polyfill

## Testing
- `CI=true npm test -- src/App.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f24e6a368832598364f3d97acd86a